### PR TITLE
fix image preprocessing

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,11 +102,14 @@ wget https://s3-us-west-2.amazonaws.com/guess-what/guesswhat.test.jsonl.gz data/
 
 To download the MS Coco dataset, please follow the following instruction:
 ```
-wget http://msvocds.blob.core.windows.net/coco2014/train2014.zip data/
+wget http://msvocds.blob.core.windows.net/coco2014/train2014.zip
 unzip train2014.zip guesswhat/data/img
 
 wget http://msvocds.blob.core.windows.net/coco2014/val2014.zip
 unzip val2014.zip guesswhat/data/img
+
+# creates a folder `plain` with filenames as expected by preprocessing script below
+python ./src/guesswhat/preprocess_data/make_cococaption_id_names.py guesswhat/data/img
 ```
 
 NB: Please check that md5sum are correct after downloading the files to check whether they have been corrupted.
@@ -138,10 +141,11 @@ To do so, you need to use the pythn script guesswhat/src/guesswhat/preprocess_da
 array=( img crop )
 for mode in "${array[@]}"; do
    python src/guesswhat/preprocess_data/extract_img_features.py \
-     -image_dir data/img
+     -image_dir data/img/plain
      -data_dir data
      -data_out data
-     -network data/vgg_16.ckpt
+     -network vgg
+     -ckpt data/vgg_16.ckpt
      -feature_name fc8
      -mode $mode
 do

--- a/src/guesswhat/preprocess_data/extract_img_features.py
+++ b/src/guesswhat/preprocess_data/extract_img_features.py
@@ -138,11 +138,10 @@ with tf.Session(config=tf.ConfigProto(gpu_options=gpu_options, allow_soft_placem
 
 if args.network == "vgg":
     print("Dump file...")
-    try:
-        # this isn't done for vgg above, only for resnet
+    
+    if not os.path.isdir(out_dir):
         os.makedirs(out_dir)
-    except FileExistsError:
-        pass
+    
     pickle_dump(features, os.path.join(out_dir, feature_name + ".pkl"))
 
 print("Done!")

--- a/src/guesswhat/preprocess_data/extract_img_features.py
+++ b/src/guesswhat/preprocess_data/extract_img_features.py
@@ -32,7 +32,7 @@ parser.add_argument("-network", type=str, choices=["resnet", "vgg"], help="Use r
 parser.add_argument("-ckpt", type=str, help="Path for network checkpoint: ")
 parser.add_argument("-feature_name", type=str, default="", help="Pick the name of the network features default=(fc8 - block4)")
 
-parser.add_argument("-mode", type=str, choice=["img", "crop"], help="Select to either dump the img/crop feature")
+parser.add_argument("-mode", type=str, choices=["img", "crop"], help="Select to either dump the img/crop feature")
 parser.add_argument("-subtract_mean", type=bool, default=True, help="Preprocess the image by substracting the mean")
 parser.add_argument("-img_size", type=int, default=224, help="image size (pixels)")
 parser.add_argument("-batch_size", type=int, default=64, help="Batch size to extract features")
@@ -47,7 +47,7 @@ args = parser.parse_args()
 
 # define image
 images = tf.placeholder(tf.float32, [None, args.img_size, args.img_size, 3], name='images')
-if args.substract_mean:
+if args.subtract_mean:
     channel_mean = np.array([123.68, 116.779, 103.939])
 else:
     channel_mean = None

--- a/src/guesswhat/preprocess_data/extract_img_features.py
+++ b/src/guesswhat/preprocess_data/extract_img_features.py
@@ -143,6 +143,6 @@ if args.network == "vgg":
         os.makedirs(out_dir)
     except FileExistsError:
         pass
-    pickle_dump(features, os.path.join(out_dir, feature_name))
+    pickle_dump(features, os.path.join(out_dir, feature_name + ".pkl"))
 
 print("Done!")

--- a/src/guesswhat/preprocess_data/extract_img_features.py
+++ b/src/guesswhat/preprocess_data/extract_img_features.py
@@ -138,6 +138,11 @@ with tf.Session(config=tf.ConfigProto(gpu_options=gpu_options, allow_soft_placem
 
 if args.network == "vgg":
     print("Dump file...")
+    try:
+        # this isn't done for vgg above, only for resnet
+        os.makedirs(out_dir)
+    except FileExistsError:
+        pass
     pickle_dump(features, os.path.join(out_dir, feature_name))
 
 print("Done!")

--- a/src/guesswhat/preprocess_data/make_cococaption_id_names.py
+++ b/src/guesswhat/preprocess_data/make_cococaption_id_names.py
@@ -1,0 +1,29 @@
+import re
+import os
+from glob import glob
+import sys
+
+
+if len(sys.argv) < 2:
+    print("Usage: python make_cococaption_id_names.py {cococaption basedir}\n\n"
+          "After unpacking cococaption zip files, you should end up with a\n"
+          "cococaption base directory with train, valid and test folder in it.\n"
+          "Provide this base dir as the first argument to this script and it\n"
+          "will create symbolic links in a new 'plain' subfolder, where each\n"
+          "link name corresponds to the original image's ID.\n"
+          "This format is expected by the guesswhat preprocessing.")
+    sys.exit(0)
+
+basepath = sys.argv[1]
+
+try:
+    os.makedirs(os.path.join(basepath, "plain"))
+except:
+    pass
+
+for path in "train2014 val2014 test2014".split():
+    for name in glob(os.path.join(basepath, path, "*")):
+        res = re.match(r'.*_0*(\d+\.\w+)$', name)
+        if not res:
+            continue
+        os.symlink(name, os.path.join(basepath, "plain", res.group(1)))

--- a/src/guesswhat/train/train_qgen_supervised.py
+++ b/src/guesswhat/train/train_qgen_supervised.py
@@ -16,7 +16,7 @@ from guesswhat.data_provider.guesswhat_tokenizer import GWTokenizer
 from generic.utils.config import load_config
 
 from guesswhat.models.qgen.qgen_lstm_network import QGenNetworkLSTM
-import guesswhat.models.qgen.qgen_beamsearch as bm
+# import guesswhat.models.qgen.qgen_beamsearch as bm
 
 from guesswhat.train.utils import get_img_loader, load_checkpoint
 

--- a/src/guesswhat/train/train_qgen_supervised.py
+++ b/src/guesswhat/train/train_qgen_supervised.py
@@ -16,7 +16,7 @@ from guesswhat.data_provider.guesswhat_tokenizer import GWTokenizer
 from generic.utils.config import load_config
 
 from guesswhat.models.qgen.qgen_lstm_network import QGenNetworkLSTM
-# import guesswhat.models.qgen.qgen_beamsearch as bm
+
 
 from guesswhat.train.utils import get_img_loader, load_checkpoint
 


### PR DESCRIPTION
- typos in preprocessing script
- discrepancy between file names contained in COCO dataset download and
  the ones expected by preprocessing script (solved by providing a
  script that creates symbolic links with the new names)
- discrepancy between image preprocessing script and README usage example