### PR TITLE
fix: json syntax does not allow final comma

### DIFF
--- a/config/guesser/config.json
+++ b/config/guesser/config.json
@@ -6,7 +6,7 @@
     "obj_mlp_units": 512,
     "dialog_emb_dim": 512,
     "spat_dim": 8,
-    "no_categories": 90,
+    "no_categories": 90
   },
 
   "optimizer": {


### PR DESCRIPTION
this actually breaks in python 3.6, not sure about other versions.