### PR TITLE
Fix GIT modeus

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,4 +9,4 @@
 	url = https://github.com/GuessWhatGame/neural_toolbox
 [submodule "src/cocoapi"]
 	path = src/cocoapi
-	url = git@github.com:GuessWhatGame/cocoapi.git
+	url = https://github.com/GuessWhatGame/cocoapi 


### PR DESCRIPTION
Coco API was not able to be cloned since it was SSH not HTTPS address. Now it works again.